### PR TITLE
fix: migrate `getStringStack` usage

### DIFF
--- a/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
+++ b/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java
@@ -233,7 +233,7 @@ public class PickpocketHelperPlugin extends Plugin {
 			return;
 		}
 
-		String message = client.getStringStack()[client.getStringStackSize() - 1];
+		String message = (String) client.getObjectStack()[client.getObjectStackSize() - 1];
 		String content = Text.removeTags(message);
 
         for (Pattern pattern : blockedPatterns) {


### PR DESCRIPTION
```
Cloning into '/tmp/pluginhub-package7045185007674590608/pickpocket-helper/repo'...
HEAD is now at 9ead9bf Release v1.0.4 (#37)
download: 1420ms

> Task :compileJava
/tmp/pluginhub-package7045185007674590608/pickpocket-helper/repo/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java:230: error: cannot find symbol
		String message = client.getStringStack()[client.getStringStackSize() - 1];
		                       ^
  symbol:   method getStringStack()
  location: variable client of type Client
/tmp/pluginhub-package7045185007674590608/pickpocket-helper/repo/src/main/java/com/pickpockethelper/PickpocketHelperPlugin.java:230: error: cannot find symbol
		String message = client.getStringStack()[client.getStringStackSize() - 1];
		                                               ^
  symbol:   method getStringStackSize()
  location: variable client of type Client
```